### PR TITLE
Añadir DbSet y eliminar configuración de conexión

### DIFF
--- a/PayFlow.DOMAIN/Infrastructure/Data/PayflowContext.cs
+++ b/PayFlow.DOMAIN/Infrastructure/Data/PayflowContext.cs
@@ -26,13 +26,6 @@ public partial class PayflowContext : DbContext
 
     public virtual DbSet<Usuarios> Usuarios { get; set; }
 
-<<<<<<< HEAD
-=======
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-#warning To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see https://go.microsoft.com/fwlink/?LinkId=723263.
-        => optionsBuilder.UseSqlServer("Server=.;Database=Payflow;User=sa;Pwd=123456789;TrustServerCertificate=True");
->>>>>>> 7013d5ff6feec32b58b477a7ea76185b6b67de1c
-
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<Administradores>(entity =>


### PR DESCRIPTION
Añadir DbSet y eliminar configuración de conexión

Se ha añadido `DbSet<Transacciones>` y `DbSet<Usuarios>` a la clase `PayflowContext`. Se ha eliminado el método `OnConfiguring`, lo que sugiere que la configuración de la conexión a la base de datos se gestionará de otra manera, posiblemente a través de un archivo de configuración o inyección de dependencias.