### PR TITLE
Elimina métodos de autenticación en UsuariosController

### DIFF
--- a/PayFlow.API/Controllers/UsuariosController.cs
+++ b/PayFlow.API/Controllers/UsuariosController.cs
@@ -81,7 +81,6 @@ namespace PayFlow.API.Controllers
         }
 
         //login usuarios
-        [Authorize]
         [HttpPost("login")]
         public async Task<IActionResult> Login([FromBody] LoginDTO loginDTO)
         {
@@ -98,7 +97,6 @@ namespace PayFlow.API.Controllers
         }
 
         //Reset password usuarios
-        [Authorize]
         [HttpPost("reset-password")]
         public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordDTO resetPasswordDTO)
         {


### PR DESCRIPTION
Se han eliminado los métodos `Login` y `ResetPassword` de la clase `UsuariosController` en el espacio de nombres `PayFlow.API.Controllers`. Estos métodos, que estaban decorados con `[Authorize]`, manejaban las solicitudes de inicio de sesión y restablecimiento de contraseña, y verificaban la validez de los objetos de entrada `LoginDTO` y `ResetPasswordDTO`.