### PR TITLE
Añadir soporte para obtener usuario por JWT

### DIFF
--- a/PayFlow.API/Controllers/UsuariosController.cs
+++ b/PayFlow.API/Controllers/UsuariosController.cs
@@ -118,5 +118,24 @@ namespace PayFlow.API.Controllers
             }
             return Ok(new { message = result });
         }
+
+        //Obtener usuario logueado por JWT
+        [Authorize]
+        [HttpGet("usuarioByjwt")]
+        public async Task<IActionResult> GetUsuarioByJwt()
+        {
+            var authHeader = Request.Headers["Authorization"].ToString();
+            if (string.IsNullOrEmpty(authHeader) || !authHeader.StartsWith("Bearer "))
+            {
+                return Unauthorized();
+            }
+            var jwtToken = authHeader.Substring("Bearer ".Length).Trim();
+            var usuario = await _usuariosService.GetUsuarioByJwtTokenAsync(jwtToken);
+            if (usuario == null)
+            {
+                return NotFound(new { message = "Usuario no encontrado o inactivo." });
+            }
+            return Ok(usuario);
+        }
     }
 }

--- a/PayFlow.DOMAIN/Core/Interfaces/IUsuariosRepository.cs
+++ b/PayFlow.DOMAIN/Core/Interfaces/IUsuariosRepository.cs
@@ -12,5 +12,6 @@ namespace PayFlow.DOMAIN.Core.Interfaces
         Task<Usuarios?> GetUsuarioByEmailAsync(string email);
         Task<bool> ResetPassword(string correo, string newPasswordHash);
         Task<Usuarios?> GetUsuarioByCorreoAsync(string Email);
+        Task<Usuarios?> GetUsuarioByJwtTokenAsync(string jwtToken);
     }
 }

--- a/PayFlow.DOMAIN/Core/Interfaces/IUsuariosService.cs
+++ b/PayFlow.DOMAIN/Core/Interfaces/IUsuariosService.cs
@@ -13,5 +13,6 @@ namespace PayFlow.DOMAIN.Core.Interfaces
         
         Task<AuthResponseDTO> LoginAsync(LoginRequestDTO loginDTO);
         Task<string> ResetPasswordAsync(ResetPasswordDTO resetPasswordDTO);
+        Task<UsuariosListDTO?> GetUsuarioByJwtTokenAsync(string jwtToken);
     }
 }

--- a/PayFlow.DOMAIN/Core/Servicies/UsuariosService.cs
+++ b/PayFlow.DOMAIN/Core/Servicies/UsuariosService.cs
@@ -182,5 +182,23 @@ namespace PayFlow.DOMAIN.Core.Servicies
             }
             return "Contraseña restablecida con éxito.";
         }
+
+        //Obtener usuario por JWT
+        public async Task<UsuariosListDTO?> GetUsuarioByJwtTokenAsync(string jwtToken)
+        {
+            var usuario = await _usuariosRepository.GetUsuarioByJwtTokenAsync(jwtToken);
+            if (usuario == null)
+            {
+                return null;
+            }
+            return new UsuariosListDTO
+            {
+                UsuarioId = usuario.UsuarioId,
+                Nombres = usuario.Nombres,
+                Apellidos = usuario.Apellidos,
+                Dni = usuario.Dni,
+                CorreoElectronico = usuario.CorreoElectronico
+            };
+        }
     }
 }

--- a/PayFlow.DOMAIN/Infrastructure/Repositories/UsuariosRepository.cs
+++ b/PayFlow.DOMAIN/Infrastructure/Repositories/UsuariosRepository.cs
@@ -3,6 +3,8 @@ using PayFlow.DOMAIN.Core.DTOs;
 using PayFlow.DOMAIN.Core.Entities;
 using PayFlow.DOMAIN.Core.Interfaces;
 using PayFlow.DOMAIN.Infrastructure.Data;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 
 namespace PayFlow.DOMAIN.Infrastructure.Repositories
 {
@@ -102,6 +104,26 @@ namespace PayFlow.DOMAIN.Infrastructure.Repositories
             _context.Usuarios.Update(usuario);
             await _context.SaveChangesAsync();
             return true;
+        }
+
+        //Obtener usuario por JWT
+        public async Task<Usuarios?> GetUsuarioByJwtTokenAsync(string jwtToken)
+        {
+            try
+            {
+                var handler = new JwtSecurityTokenHandler();
+                var token = handler.ReadJwtToken(jwtToken);
+                var usuarioIdClaim = token.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier);
+                if (usuarioIdClaim != null && int.TryParse(usuarioIdClaim.Value, out int usuarioId))
+                {
+                    return await _context.Usuarios.FirstOrDefaultAsync(x => x.UsuarioId == usuarioId && x.EstadoUsuario == "Activo");
+                }
+                return null;
+            }
+            catch
+            {
+                return null; // Si hay un error al procesar el token, retornar null
+            }
         }
     }
 }


### PR DESCRIPTION
Se ha implementado un nuevo método en el controlador `UsuariosController` para obtener un usuario autenticado a través de un token JWT, incluyendo la verificación del encabezado de autorización.

Se han agregado métodos en las interfaces `IUsuariosRepository` e `IUsuariosService` para facilitar la obtención de usuarios utilizando un token JWT.

Además, se han implementado los métodos correspondientes en las clases `UsuariosService` y `UsuariosRepository` para procesar el token y buscar el usuario activo en la base de datos.